### PR TITLE
fix first link in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <figure class="hero" title="Collaborative meeting"></figure>
     <!--"article" used for main content of page w each subsection of main content placed w/in a section vs in a div-->
     <article class="content">
-        <section id="#search-engine-optimization">
+        <section id="search-engine-optimization">
             <img class="float-left" src="./Develop/assets/images/search-engine-optimization.jpg" alt="Notebook with illustrations of SEO optimizers next to a laptop"/>
             <!--each header w/in this section set to h2 for equal font size per section title-->
             <h2>Search Engine Optimization</h2>


### PR DESCRIPTION
Link was broken bc the id in the corresponding section had been copied from the navbar section so it still had the # in front of it.